### PR TITLE
Fix the unit tests by adding missing parameter

### DIFF
--- a/tests/test_libthumbor.py
+++ b/tests/test_libthumbor.py
@@ -31,6 +31,7 @@ def test_usage():
         flip_vertical=False,
         halign='center',
         valign='middle',
+        trim=None,
         crop_left=0,
         crop_top=0,
         crop_right=0,


### PR DESCRIPTION
Without the fix, here is the test command and error:

nosetests -v -s tests
# 
## ERROR: test_libthumbor.test_usage

Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/fdu/Documents/work/fork/libthumbor/tests/test_libthumbor.py", line 39, in test_usage
    image=image
TypeError: encrypt() takes exactly 17 arguments (16 given)

---
