### PR TITLE
py3k compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 dist
 libthumbor.egg-info
 *.db
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 
 install:
     # update aptitude

--- a/libthumbor/__init__.py
+++ b/libthumbor/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 # libthumbor - python extension to thumbor
 # http://github.com/heynemann/libthumbor

--- a/libthumbor/django/urls.py
+++ b/libthumbor/django/urls.py
@@ -1,5 +1,8 @@
-from django.conf.urls.defaults import patterns, url
+from __future__ import unicode_literals
 
-urlpatterns = patterns('libthumbor.django.views',
-    url("^$", 'generate_url', name="generate_thumbor_url"),
-)
+from django.conf.urls.defaults import url
+from libthumbor.django.views import generate_url
+
+urlpatterns = [
+    url('^$', generate_url, name='thumbor_url'),
+]

--- a/libthumbor/django/views.py
+++ b/libthumbor/django/views.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 # libthumbor - python extension to thumbor
 # http://github.com/heynemann/libthumbor
@@ -38,14 +39,14 @@ def generate_url(request):
     try:
         if 'width' in args:
             args['width'] = int(args['width'])
-    except ValueError, e:
+    except ValueError:
         error_message = "The width value '%s' is not an integer." % \
             args['width']
 
     try:
         if 'height' in args:
             args['height'] = int(args['height'])
-    except ValueError, e:
+    except ValueError:
         error_message = "The height value '%s' is not an integer." % \
             args['height']
 
@@ -53,9 +54,9 @@ def generate_url(request):
         if 'crop_top' in args or 'crop_left' in args or 'crop_right' in args or 'crop_bottom' in args:
             args['crop'] = ((int(args['crop_left']), int(args['crop_top'])),
                     (int(args['crop_right']), int(args['crop_bottom'])))
-    except KeyError, e:
+    except KeyError:
         error_message = "Missing values for cropping. Expected all 'crop_left', 'crop_top', 'crop_right', 'crop_bottom' values."
-    except ValueError, e:
+    except ValueError:
         error_message = "Invalid values for cropping. Expected all 'crop_left', 'crop_top', 'crop_right', 'crop_bottom' to be integers."
 
     if error_message is not None:
@@ -64,7 +65,7 @@ def generate_url(request):
 
     try:
         return HttpResponse(THUMBOR_SERVER + crypto.generate(**args).strip("/"), mimetype="text/plain")
-    except (ValueError, KeyError), e:
+    except (ValueError, KeyError) as e:
         error_message = str(e)
         logging.warning(error_message)
         return HttpResponseBadRequest(error_message)

--- a/libthumbor/url.py
+++ b/libthumbor/url.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 # libthumbor - python extension to thumbor
 # http://github.com/heynemann/libthumbor

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 # libthumbor - python extension to thumbor
 # http://github.com/heynemann/libthumbor
 
-# Licensed under the MIT license: 
+# Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 Bernardo Heynemann heynemann@gmail.com
 
@@ -31,7 +31,7 @@ setup(
     long_description = """
 libthumbor is the python extension to thumbor.
 It allows users to generate safe urls easily.
-""",    
+""",
     keywords = 'imaging face detection feature thumbor thumbnail' + \
                ' imagemagick pil opencv',
     author = 'Bernardo Heynemann',
@@ -59,7 +59,5 @@ It allows users to generate safe urls easily.
     },
 
     install_requires=[
-        "pyCrypto"
     ],
 )
-

--- a/tests/test_url_composer.py
+++ b/tests/test_url_composer.py
@@ -49,7 +49,7 @@ def test_url_raises_if_no_url():
     '''
     try:
         url_for()
-    except ValueError, err:
+    except ValueError as err:
         assert str(err) == 'The image_url argument is mandatory.'
         return True
     assert False, 'Should not have gotten this far'
@@ -487,7 +487,7 @@ def test_proper_haligns():
     '''test_proper_haligns'''
     try:
         url_for(halign='wrong', image_url=IMAGE_URL)
-    except ValueError, err:
+    except ValueError as err:
         assert str(err) == 'Only "left", "center" and "right"' + \
                            ' are valid values for horizontal alignment.'
         return True
@@ -497,7 +497,7 @@ def test_proper_valigns():
     '''test_proper_haligns'''
     try:
         url_for(valign='wrong', image_url=IMAGE_URL)
-    except ValueError, err:
+    except ValueError as err:
         assert str(err) == 'Only "top", "middle" and "bottom"' + \
                            ' are valid values for vertical alignment.'
         return True

--- a/tests/testproj/manage.py
+++ b/tests/testproj/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from django.core.management import execute_manager
 try:
-    import settings # Assumed to be in the same directory.
+    import settings  # Assumed to be in the same directory.
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)


### PR DESCRIPTION
Hi there

I've added initial Python 3 compatibility.
This is of course just for the client library so I can generate safe Thumbor urls in py3k projects as well. The Thumbor server itself still has to run in its own Python 2 environment.

Please review but do not merge this yet, as I'm still unhappy with this quality myself. ;)