### PR TITLE
Fix test_usage test related to changes on the thumbor api

### DIFF
--- a/tests/test_libthumbor.py
+++ b/tests/test_libthumbor.py
@@ -26,6 +26,7 @@ def test_usage():
         height=200,
         smart=True,
         adaptive=False,
+        full=False,
         fit_in=False,
         flip_horizontal=False,
         flip_vertical=False,


### PR DESCRIPTION
I am not sure what is the testing strategy with different versions of Thumbor but I noticed that tests where failing with versions of thumbor higher than 4.2.1.
