### PR TITLE
Fix PyCrypto imports on Case-Insensitive filesystems

### DIFF
--- a/libthumbor/crypto.py
+++ b/libthumbor/crypto.py
@@ -10,6 +10,8 @@
 
 '''Encrypted URLs for thumbor encryption.'''
 
+from __future__ import absolute_import
+
 import base64
 import hmac
 import hashlib


### PR DESCRIPTION
PyCrypto fails to import when running in a case insensitive filesystem (eg. Vagrant NFS mount on OSX). 
Under that scenario, python tries to import the local crypto modulo instead of Crypto.  Using absolute_import is a way around that issue.

Here's a similar issue on the OpenStack Nova project:  
https://bugs.launchpad.net/nova/+bug/925792
