### PR TITLE
Performance improvements

### DIFF
--- a/libthumbor/crypto.py
+++ b/libthumbor/crypto.py
@@ -45,7 +45,7 @@ class CryptoURL(object):
             key = str(key)
         self.key = key
         self.computed_key = (key * 16)[:16]
-        self.hmac = hmac.new(key, digestmod=hashlib.sha1)
+        self.hmac = hmac.new(b(key), digestmod=hashlib.sha1)
         self.thread_safe = thread_safe
 
     def generate_old(self, options):
@@ -62,7 +62,7 @@ class CryptoURL(object):
     def generate_new(self, options):
         url = plain_image_url(**options)
         _hmac = self.hmac.copy() if self.thread_safe else self.hmac
-        _hmac.update(url)
+        _hmac.update(text_type(url).encode('utf-8'))
         signature = base64.urlsafe_b64encode(_hmac.digest())
 
         if PY3:

--- a/libthumbor/crypto.py
+++ b/libthumbor/crypto.py
@@ -30,8 +30,14 @@ from libthumbor.url import url_for, unsafe_url, plain_image_url
 class CryptoURL(object):
     '''Class responsible for generating encrypted URLs for thumbor'''
 
-    def __init__(self, key):
-        '''Initializes the encryptor with the proper key'''
+    def __init__(self, key, thread_safe=True):
+        '''
+        Initializes the encryptor with the proper key
+        :param key: secret key to use for hashing.
+        :param thread_safe: if True (default) CryptoURL will not reuse the hmac instance on every generate call,
+         instead a copy of the hmac object will be created. Consider setting this parameter to False when only one
+         thread has access to the CryptoURL object at a time.
+        '''
         if not PYCRYPTOFOUND:
             raise RuntimeError('pyCrypto could not be found,' +
                                ' please install it before using libthumbor')
@@ -39,6 +45,8 @@ class CryptoURL(object):
             key = str(key)
         self.key = key
         self.computed_key = (key * 16)[:16]
+        self.hmac = hmac.new(key, digestmod=hashlib.sha1)
+        self.thread_safe = thread_safe
 
     def generate_old(self, options):
         url = url_for(**options)
@@ -53,7 +61,9 @@ class CryptoURL(object):
 
     def generate_new(self, options):
         url = plain_image_url(**options)
-        signature = base64.urlsafe_b64encode(hmac.new(b(self.key), text_type(url).encode('utf-8'), hashlib.sha1).digest())
+        _hmac = self.hmac.copy() if self.thread_safe else self.hmac
+        _hmac.update(url)
+        signature = base64.urlsafe_b64encode(_hmac.digest())
 
         if PY3:
             signature = signature.decode('ascii')


### PR DESCRIPTION
Re-use hmac object instead of creating a new one from scratch on every generate() call.

40% shorter running time for generate() function with thread_safe set to False, or 30% running time improvement when thread_safe parameter is true.

Code used to measure running time:
```
from libthumbor import CryptoURL
import cProfile


def generate():
    base_url = 'http://example.com/images{}.jpeg'
    crypto = CryptoURL(key='example_key_here')
    for i in xrange(200001):
        crypto.generate(image_url=base_url.format(i))

if __name__ == '__main__':
    cProfile.run('generate()', sort='cumulative')
```

Before the change:
```
   10400079 function calls in 4.910 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    4.910    4.910 <string>:1(<module>)
        1    0.136    0.136    4.910    4.910 load_test.py:5(generate)
   200001    0.179    0.000    4.701    0.000 crypto.py:62(generate)
   200001    0.610    0.000    4.480    0.000 crypto.py:54(generate_new)
```

After, thread_safe=True:
```
   8400061 function calls in 3.483 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    3.483    3.483 <string>:1(<module>)
        1    0.153    0.153    3.483    3.483 load_test.py:11(generate)
   200001    0.220    0.000    3.225    0.000 crypto.py:72(generate)
   200001    0.430    0.000    2.966    0.000 crypto.py:62(generate_new)
```
After, thread_safe=False:

```
   7600057 function calls in 2.985 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.985    2.985 <string>:1(<module>)
        1    0.151    0.151    2.985    2.985 load_test.py:11(generate)
   200001    0.167    0.000    2.732    0.000 crypto.py:72(generate)
   200001    0.355    0.000    2.525    0.000 crypto.py:62(generate_new)
```