### PR TITLE
Removing thread_safe parameter.

### DIFF
--- a/libthumbor/crypto.py
+++ b/libthumbor/crypto.py
@@ -30,7 +30,7 @@ from libthumbor.url import url_for, unsafe_url, plain_image_url
 class CryptoURL(object):
     '''Class responsible for generating encrypted URLs for thumbor'''
 
-    def __init__(self, key, thread_safe=True):
+    def __init__(self, key):
         '''
         Initializes the encryptor with the proper key
         :param key: secret key to use for hashing.
@@ -46,7 +46,6 @@ class CryptoURL(object):
         self.key = key
         self.computed_key = (key * 16)[:16]
         self.hmac = hmac.new(b(key), digestmod=hashlib.sha1)
-        self.thread_safe = thread_safe
 
     def generate_old(self, options):
         url = url_for(**options)
@@ -61,7 +60,7 @@ class CryptoURL(object):
 
     def generate_new(self, options):
         url = plain_image_url(**options)
-        _hmac = self.hmac.copy() if self.thread_safe else self.hmac
+        _hmac = self.hmac.copy()
         _hmac.update(text_type(url).encode('utf-8'))
         signature = base64.urlsafe_b64encode(_hmac.digest())
 

--- a/tests/test_cryptourl.py
+++ b/tests/test_cryptourl.py
@@ -316,6 +316,14 @@ class NewFormatUrlTestsMixin:
         url = self.crypto.generate(image_url=IMAGE_URL, width=300, height=200, crop=((10,10), (200,200)), filters=("brightness(20)", "contrast(10)"))
         assert url == '/as8U2DbUUtTMgvPF26LkjS3MocY=/10x10:200x200/300x200/filters:brightness(20):contrast(10)/my.server.com/some/path/to/image.jpg'
 
+    def test_generated_url_4(self):
+        url = self.crypto.generate(image_url=IMAGE_URL, width=300, height=200, crop=((10,10), (200,200)), filters=("brightness(20)", "contrast(10)"))
+        assert url == '/as8U2DbUUtTMgvPF26LkjS3MocY=/10x10:200x200/300x200/filters:brightness(20):contrast(10)/my.server.com/some/path/to/image.jpg'
+        # making sure no internal state affects subsequent calls.
+        url = self.crypto.generate(image_url=IMAGE_URL, width=300, height=200, crop=((10,10), (200,200)), filters=("brightness(20)", "contrast(10)"))
+        assert url == '/as8U2DbUUtTMgvPF26LkjS3MocY=/10x10:200x200/300x200/filters:brightness(20):contrast(10)/my.server.com/some/path/to/image.jpg'
+
+
 class NewFormatUrl(TestCase, NewFormatUrlTestsMixin):
     def setUp(self):
         self.crypto = CryptoURL(KEY)


### PR DESCRIPTION
According to https://docs.python.org/2/library/hashlib.html, subsequent calls to hmac.update() do not replace the message, but extend it. So we have to use an hmac copy on every generate() call to generate correct signature for calls after the first one.