### PR TITLE
Make coverage call more platform-agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+COVERAGE = $(or $(shell which coverage), $(shell which python-coverage), coverage)
+
 test ci_test:
-	@coverage run --branch `which nosetests` -v --with-yanc -s tests/
+	@$(COVERAGE) run --branch `which nosetests` -v --with-yanc -s tests/
 	@$(MAKE) coverage
 	@$(MAKE) static
 
 coverage:
-	@coverage report -m --fail-under=75
+	
+	@$(COVERAGE) report -m --fail-under=75
 
 publish:
 	python setup.py sdist upload


### PR DESCRIPTION
This allows the Makefile to work on debian where coverage
was installed via the python-coverage debian package.