### PR TITLE
Ignore querystring when generating HMAC for safe URLs.

### DIFF
--- a/libthumbor/crypto.py
+++ b/libthumbor/crypto.py
@@ -42,7 +42,7 @@ class CryptoURL(object):
     def generate_new(self, options):
         url = plain_image_url(**options)
         _hmac = self.hmac.copy()
-        _hmac.update(text_type(url).encode('utf-8'))
+        _hmac.update(text_type(url.split('?')[0]).encode('utf-8'))
         signature = base64.urlsafe_b64encode(_hmac.digest())
 
         if PY3:


### PR DESCRIPTION
While adding support for signed AWS S3 URLs via the default HTTP loader,
I discovered that Thumbor ignores the querystring when validating the
HMAC (https://github.com/thumbor/thumbor/blob/6066995c225a8e5a82dbd0453d8e48f4584538ab/thumbor/context.py#L205),
while libthumbor does not.

This change ensures that libthumbor will generate safe URLs that can be
validated by Thumbor, even when they include a querystring.