### PR TITLE
Python3 compatible info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.2'
   - '3.3'
   - '3.4'
   - '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
-  - '3.7'
   - pypy
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - '3.3'
   - '3.4'
   - '3.5'
+  - '3.6'
+  - '3.7'
   - pypy
 cache:
   directories:

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -8,7 +8,7 @@ First step is to fork it at http://help.github.com/fork-a-repo/ and create your 
 
 We seriously advise you to use virtualenv (http://pypi.python.org/pypi/virtualenv) since it will keep your environment clean of libthumbor's dependencies and you can choose when to "turn them on".
 
-You'll also need python >= 2.6 and < 3.0.
+You'll also need python >= 2.6 or >= 3.0.
 
 After that, just issue a `make setup` command and you'll be ready to start hacking.
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 from setuptools import setup, find_packages
 
 tests_require = [
-    'setuptools',
     'nose',
     'coverage',
     'yanc',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ It allows users to generate safe urls easily.
     },
 
     install_requires=[
-        "six>=0.11"
+        "six==1.10.0"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 from setuptools import setup, find_packages
 
 tests_require = [
+    'setuptools',
     'nose',
     'coverage',
     'yanc',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ It allows users to generate safe urls easily.
     },
 
     install_requires=[
-        "six"
+        "six>=0.11"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ It allows users to generate safe urls easily.
                  'Operating System :: MacOS',
                  'Operating System :: POSIX :: Linux',
                  'Programming Language :: Python :: 2.6',
+                 'Programming Language :: Python :: 3',
                  'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
                  'Topic :: Multimedia :: Graphics :: Presentation'
                  ],


### PR DESCRIPTION
- Added python3 version as compatible on trove classifier
- Changed required python versions at contributing guidelines

Please, after merge this, release a new version to make libthumbor detected as py3 compatible project.

Fixed #35 