### PR TITLE
Move the version number from setup.py to libthumbor/__init__.py

### DIFF
--- a/libthumbor/__init__.py
+++ b/libthumbor/__init__.py
@@ -10,15 +10,8 @@
 
 '''libthumbor is the library used to access thumbor's images in python'''
 
-from pkg_resources import get_distribution, DistributionNotFound
-
 __project__ = 'libthumbor'
-
-try:
-    __version__ = get_distribution(__project__).version
-except DistributionNotFound:
-    # Returns a local version. For tests.
-    __version__ = '{}-local'.format(__project__)
+__version__ = '1.3.2'
 
 from libthumbor.crypto import CryptoURL  # NOQA
 from libthumbor.url import Url  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@
 
 '''Module that configures setuptools to package libthumbor'''
 
+import ast
+import os.path
 from setuptools import setup, find_packages
 
 tests_require = [
@@ -20,9 +22,21 @@ tests_require = [
     'flake8',
 ]
 
+
+class GetVersion(ast.NodeVisitor):
+    def __init__(self, path):
+        with open(path) as f:
+            self.visit(ast.parse(f.read(), path))
+
+    def visit_Assign(self, node):
+        if any(target.id == '__version__' for target in node.targets):
+            assert not hasattr(self, '__version__')
+            self.__version__ = node.value.s
+
+
 setup(
     name='libthumbor',
-    version="1.3.2",
+    version=GetVersion(os.path.join(os.path.dirname(__file__), 'libthumbor', '__init__.py')).__version__,
     description="libthumbor is the python extension to thumbor",
     long_description="""
 libthumbor is the python extension to thumbor.


### PR DESCRIPTION
This avoids the runtime cost of importing `pkg_resources`, which is typically in the hundreds of milliseconds.