### PR TITLE
Supporting python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 3.6
   - 3.7
   - 3.8
 cache:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ keywords = ["imaging", "face", "detection", "feature", "thumbor", "thumbnail", "
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.6"
 six = "^1.14.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
There's not reason not to allow generating URLs in python 3.6.