### PR TITLE
Remove six as in adieu

### DIFF
--- a/libthumbor/crypto.py
+++ b/libthumbor/crypto.py
@@ -16,8 +16,6 @@ import base64
 import hashlib
 import hmac
 
-from six import b, text_type
-
 from libthumbor.url import plain_image_url, unsafe_url
 
 
@@ -30,15 +28,15 @@ class CryptoURL:
         :param key: secret key to use for hashing.
         """
 
-        if isinstance(key, text_type):
-            key = b(key)
+        if isinstance(key, str):
+            key = key.encode("latin-1")
         self.key = key
         self.hmac = hmac.new(self.key, digestmod=hashlib.sha1)
 
     def generate_new(self, options):
         url = plain_image_url(**options)
         _hmac = self.hmac.copy()
-        _hmac.update(text_type(url).encode("utf-8"))
+        _hmac.update(url.encode("utf-8"))
         signature = base64.urlsafe_b64encode(_hmac.digest()).decode("ascii")
 
         return f"/{signature}/{url}"

--- a/libthumbor/url.py
+++ b/libthumbor/url.py
@@ -15,8 +15,6 @@
 import hashlib
 import re
 
-from six import b
-
 AVAILABLE_HALIGN = ["left", "center", "right"]
 AVAILABLE_VALIGN = ["top", "middle", "bottom"]
 
@@ -50,7 +48,7 @@ def url_for(**options):
     """Returns the url for the specified options"""
 
     url_parts = get_url_parts(**options)
-    image_hash = hashlib.md5(b(options["image_url"])).hexdigest()
+    image_hash = hashlib.md5(options["image_url"].encode("latin-1")).hexdigest()
     url_parts.append(image_hash)
 
     return "/".join(url_parts)

--- a/libthumbor/url_signers/__init__.py
+++ b/libthumbor/url_signers/__init__.py
@@ -8,12 +8,10 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
-from six import text_type
-
 
 class BaseUrlSigner:
     def __init__(self, security_key):
-        if isinstance(security_key, text_type):
+        if isinstance(security_key, str):
             security_key = security_key.encode("utf-8")
         self.security_key = security_key
 

--- a/libthumbor/url_signers/base64_hmac_sha1.py
+++ b/libthumbor/url_signers/base64_hmac_sha1.py
@@ -4,8 +4,6 @@ import base64
 import hashlib
 import hmac
 
-from six import text_type
-
 from libthumbor.url_signers import BaseUrlSigner
 
 
@@ -14,7 +12,5 @@ class UrlSigner(BaseUrlSigner):
 
     def signature(self, url):
         return base64.urlsafe_b64encode(
-            hmac.new(
-                self.security_key, text_type(url).encode("utf-8"), hashlib.sha1
-            ).digest()
+            hmac.new(self.security_key, url.encode("utf-8"), hashlib.sha1).digest()
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,7 +386,7 @@ python-versions = "*"
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -453,7 +453,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9348275036606def7f798fd802e9e233918c13e28edd85e8132dc15adaad7315"
+content-hash = "3e79c644c7fed3857318412769ceb1abd35fb826c5db5ecf8217fb385f13833a"
 
 [metadata.files]
 asgiref = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-six = "^1.14.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"

--- a/tests/test_cryptourl.py
+++ b/tests/test_cryptourl.py
@@ -100,3 +100,14 @@ class GenerateWithUnsafeTestCase(TestCase):
             image_url=IMAGE_URL, crop=((10, 20), (30, 40)), unsafe=False
         )
         expect(url.startswith("unsafe")).to_be_false()
+
+
+class KeyWithSpecialCharactersTestCase(TestCase):
+    def setUp(self):
+        self.crypto = CryptoURL("cafécompãodequeijo")
+
+    def test_should_generate_url_with_key_with_special_characters(self):
+        url = self.crypto.generate(image_url=IMAGE_URL)
+        expect(url).to_equal(
+            "/MrRd4GRirTQ0JO3vM2slr4rT5Fk=/my.server.com/some/path/to/image.jpg"
+        )

--- a/tests/test_cryptourl.py
+++ b/tests/test_cryptourl.py
@@ -13,7 +13,6 @@
 from unittest import TestCase
 
 from preggy import expect
-from six import ensure_text
 
 from libthumbor.crypto import CryptoURL
 
@@ -83,7 +82,7 @@ class NewFormatUrl(TestCase, NewFormatUrlTestsMixin):
 
 class NewFormatUrlWithUnicodeKey(TestCase, NewFormatUrlTestsMixin):
     def setUp(self):
-        self.crypto = CryptoURL(ensure_text(KEY))
+        self.crypto = CryptoURL(KEY)
 
 
 class GenerateWithUnsafeTestCase(TestCase):

--- a/tests/test_libthumbor.py
+++ b/tests/test_libthumbor.py
@@ -10,8 +10,6 @@
 
 import re
 
-from six import b
-
 from libthumbor import CryptoURL, Url, Signer
 
 
@@ -56,4 +54,4 @@ def test_thumbor_can_decrypt_lib_thumbor_generated_url_new_format():
     reg = "/([^/]+)/(.+)"
     (signature, url) = re.match(reg, url).groups()
 
-    assert thumbor_signer.validate(b(signature), url)
+    assert thumbor_signer.validate(signature.encode(), url)

--- a/tests/test_url_composer.py
+++ b/tests/test_url_composer.py
@@ -576,6 +576,20 @@ def test_smart_after_alignments():
     expect("left/smart/84996242f65a4d864aceb125e1c4c5ba").to_equal(url)
 
 
+def test_no_options_specified_and_image_with_special_chars():
+    """test_no_options_specified
+    Given
+        An image URL of "my.server.com/some/path/to/image-of-pão-de-açúcar.jpg"
+    When
+        I ask my library for an URL with special chars
+    Then
+        I get "a0307329a0373ad42c1987098988573f" as URL
+    """
+    url = url_for(image_url="my.server.com/some/path/to/image-of-pão-de-açúcar.jpg")
+
+    expect(url).to_equal("a0307329a0373ad42c1987098988573f")
+
+
 class UnsafeUrlTestCase(TestCase):
     def test_should_return_a_valid_unsafe_url_with_no_params(self):
         expect(f"unsafe/{IMAGE_URL}").to_equal(unsafe_url(image_url=IMAGE_URL))

--- a/tests/url_signers/test_base64_hmac_sha1_signer.py
+++ b/tests/url_signers/test_base64_hmac_sha1_signer.py
@@ -16,7 +16,6 @@ import hmac
 from unittest import TestCase
 
 from preggy import expect
-from six import text_type
 
 from libthumbor.url_signers.base64_hmac_sha1 import UrlSigner
 
@@ -31,9 +30,7 @@ class Base64HmacSha1UrlSignerTestCase(TestCase):
         signer = UrlSigner(security_key="something")
         url = "10x11:12x13/-300x-300/center/middle/smart/some/image.jpg"
         expected = base64.urlsafe_b64encode(
-            hmac.new(
-                "something".encode(), text_type(url).encode("utf-8"), hashlib.sha1
-            ).digest()
+            hmac.new("something".encode(), url.encode("utf-8"), hashlib.sha1).digest()
         )
         actual = signer.signature(url)
         expect(actual).to_equal(expected)


### PR DESCRIPTION
Following the trend started in #51, I guess we can get rid of `six`.

I followed both https://six.readthedocs.io/ and https://github.com/benjaminp/six/blob/master/six.py to replace the usages of `six`. If anyone spot something not quite right, I'll be happy to address it.